### PR TITLE
Se modifico la edición de documentos de CAM y CE

### DIFF
--- a/app/Http/Controllers/EconomicComplementController.php
+++ b/app/Http/Controllers/EconomicComplementController.php
@@ -732,15 +732,29 @@ class EconomicComplementController extends Controller
         $procedure_types = ProcedureType::where('module_id', ID::module()->eco_com)->get();
         $procedure_requirements = ProcedureRequirement::select('procedure_requirements.id', 'procedure_documents.name as document', 'number', 'procedure_modality_id as modality_id')
             ->leftJoin('procedure_documents', 'procedure_requirements.procedure_document_id', '=', 'procedure_documents.id')
+            ->where('procedure_modality_id', $economic_complement->eco_com_modality->procedure_modality_id)
             ->orderBy('procedure_requirements.procedure_modality_id', 'ASC')
             ->orderBy('procedure_requirements.number', 'ASC')
             ->get();
         $procedure_modalities = ProcedureModality::where('procedure_type_id', '=', ID::procedureType()->eco_com)->select('id', 'name', 'procedure_type_id')->get();
-        $submitted = EcoComSubmittedDocument::select('eco_com_submitted_documents.id', 'procedure_requirements.number', 'eco_com_submitted_documents.procedure_requirement_id', 'eco_com_submitted_documents.comment', 'eco_com_submitted_documents.is_valid', 'eco_com_submitted_documents.is_uploaded')
+        $submitted = EcoComSubmittedDocument::select('eco_com_submitted_documents.id', 'procedure_requirements.number', 'eco_com_submitted_documents.procedure_requirement_id', 'eco_com_submitted_documents.comment', 'eco_com_submitted_documents.is_valid', 'eco_com_submitted_documents.is_uploaded', 'procedure_documents.name')
             ->leftJoin('procedure_requirements', 'eco_com_submitted_documents.procedure_requirement_id', '=', 'procedure_requirements.id')
+            ->join('procedure_documents', 'procedure_requirements.procedure_document_id', '=', 'procedure_documents.id')
             ->orderby('procedure_requirements.number', 'ASC')
             ->where('eco_com_submitted_documents.economic_complement_id', $id);
 
+        // Sirve para listar documentos que fueron eliminados anteriormente
+        $hash_procedure_requirements = $procedure_requirements->mapWithKeys(function ($item) {
+            return [$item->id => $item];
+        });
+        $restore_procedure_documents = collect();
+        foreach ($submitted->get() as $item) {
+            if(!isset($hash_procedure_requirements[$item->procedure_requirement_id])){
+                $restore_procedure_documents->push(['id'=>$item->procedure_requirement_id, 'document' =>$item->name, 'number'=>$item->number ]);
+            }
+        }
+        $procedure_requirements = collect($procedure_requirements)->merge($restore_procedure_documents);
+        
         /**
          ** for validation and submit
          */

--- a/app/Http/Controllers/RetirementFundController.php
+++ b/app/Http/Controllers/RetirementFundController.php
@@ -643,6 +643,18 @@ class RetirementFundController extends Controller
             ->orderby('procedure_requirements.number', 'ASC')
             ->where('ret_fun_submitted_documents.retirement_fund_id', $id);
         
+        // Sirve para listar documentos que fueron eliminados anteriormente
+        $hash_procedure_requirements = $procedure_requirements->mapWithKeys(function ($item) {
+            return [$item->id => $item];
+        });
+        $restore_procedure_documents = collect();
+        foreach ($submitted->get() as $item) {
+            if(!isset($hash_procedure_requirements[$item->procedure_requirement_id])){
+                $restore_procedure_documents->push(['id'=>$item->procedure_requirement_id, 'document' =>$item->name, 'number'=>$item->number ]);
+            }
+        }
+        $procedure_requirements = collect($procedure_requirements)->merge($restore_procedure_documents);
+
         // return $submitted->get();
         // ->pluck('ret_fun_submitted_documents.procedure_requirement_id','procedure_requirements.number');
         /**for validate doc*/

--- a/resources/assets/js/components/quota_aid/Step1RequirementsEdit.vue
+++ b/resources/assets/js/components/quota_aid/Step1RequirementsEdit.vue
@@ -11,11 +11,6 @@
                         Editar</button>
                 </div>
             </div>
-            <div class="row" v-if="errorsValidate.length > 0">
-                <div v-for="err in errorsValidate" :key="err" class="alert alert-danger">
-                    <i class="fa fa-exclamation-triangle"></i> {{ err }}
-                </div>
-            </div>
             <form>
                 <div class="row">
                     <div v-for="(requirement, index) in requirementList" :key="index">
@@ -47,10 +42,6 @@
                                     <div class="vote-icon">
                                         <span style="color:#3c3c3c"><i class="fa "
                                                 :class="rq.status ? 'fa-check-square' : 'fa-square-o'"></i></span>
-                                        <div style="opacity:0" v-if="rol != 38">
-                                            <input type="checkbox" v-model="rq.status" value="checked"
-                                                :name="'document' + rq.id" class="largerCheckbox">
-                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -98,17 +89,17 @@ export default {
         'affiliate',
         'quota_aid',
         'submitted',
+        'requirements',
         'rol',
     ],
     data() {
         return {
-            requirementList: [],
+            requirementList: {},
             aditionalRequirements: [],
             aditionalRequirementsUploaded: [],
             aditionalRequirementsSelected: [],
             modality: null,
             editing: false,
-            errorsValidate: [],
             additionalCounter: 100, // Este numero se usa como indice en los requisitos con numero 0 para que se grafiquen al final de la lista
         }
     },
@@ -131,78 +122,88 @@ export default {
             }, 500);
         },
         async getRequirements() {
-            // Si el rol es 38, mapear directamente la lista sin llamar al backend            
-            if (this.rol === 38) {
-                const temp = {};
-                this.submitted.map(submit => {
-                    const index = submit.number > 0 ? submit.number : this.additionalCounter;
-                    if (!temp[index]) {
-                        temp[index] = [];
-                    }
-                    temp[index].push({
-                        id: submit.id,
-                        name: submit.name,
-                        status: submit.is_valid,
-                        background: submit.is_valid ? 'bg-success-green' : '',
-                        comment: submit.comment,
-                        isUploaded: submit.is_uploaded,
-                        procedureRequirementId: submit.procedure_requirement_id,
-                        number: submit.number
+            const isLegalReview = this.rol == 38;
+
+            this.aditionalRequirementsUploaded = [];
+            this.aditionalRequirements = [];
+
+            if (isLegalReview) {
+                this.requirementList = this.submitted.reduce((acc, sub) => {
+                    const index = sub.number > 0 ? sub.number : this.additionalCounter;
+
+                    if (!acc[index]) acc[index] = [];
+
+                    acc[index].push({
+                        id: sub.id,
+                        name: sub.name,
+                        status: sub.is_valid,
+                        background: sub.is_valid ? 'bg-success-green' : '',
+                        comment: sub.comment,
+                        isUploaded: sub.is_uploaded,
+                        procedureRequirementId: sub.procedure_requirement_id,
+                        number: sub.number
                     });
-                });
-                this.requirementList = temp;
-                this.aditionalRequirements = [];
-                this.aditionalRequirementsSelected = [];
-                return;
-            }
 
-            // Si no es rol 38, obtener los documentos desde la API
-            const uri = `/gateway/api/affiliates/${this.affiliate.id}/modality/${this.modality}/collate`;
-
-            try {
-                const { data } = await axios.get(uri);
-
-                const submittedMap = new Map(
-                    this.submitted.map(doc => [doc.procedure_requirement_id, doc])
-                );
-
-                this.requirementList = Object.values(data.requiredDocuments).map(group =>
-                    group.map(doc => this.processRequirement(doc, submittedMap.get(doc.procedureRequirementId)))
-                );
-
-                this.aditionalRequirementsUploaded = data.additionallyDocumentsUpload || [];
-                this.aditionalRequirements = data.additionallyDocuments || [];
-            } catch (error) {
-                console.error('Error al obtener los requisitos:', error);
-            }
-
-            this.getAditionalRequirements(); // si esta función es necesaria
-        },
-        processRequirement(requirement, submittedDoc) {
-            const r = { ...requirement }; // copia para no mutar directamente
-
-            if (!submittedDoc) {
-                r.status = false;
-                r.background = '';
-                r.comment = null;
-                return r;
-            }
-
-            r.comment = submittedDoc.comment;
-            r.submit_document_id = submittedDoc.id;
-
-            if (this.rol !== 38) {
-                if (submittedDoc.is_uploaded !== r.isUploaded) {
-                    this.errorsValidate.push(`El documento "${r.name}" no coincide con el archivo escaneado.`);
-                }
-                r.status = true;
-                r.background = r.isUploaded ? 'bg-success-blue' : 'bg-success-green';
+                    return acc;
+                }, {});
             } else {
-                r.status = submittedDoc.is_valid;
-                r.background = submittedDoc.is_valid ? 'bg-success-green' : '';
+                const submittedMap = new Map(
+                    this.submitted.map(s => [s.procedure_requirement_id, s])
+                );
+
+                const acc = {};
+
+                this.requirements.forEach(req => {
+                    const sub = submittedMap.get(req.id);
+
+                    if (req.number === 0) {
+                        const opReq = {
+                            name: req.document,
+                            number: req.number,
+                            procedureRequirementId: req.id,
+                            isUploaded: sub ? sub.is_uploaded : false
+                        };
+
+                        if (opReq.isUploaded) {
+                            this.aditionalRequirementsUploaded.push(opReq);
+                        } else {
+                            this.aditionalRequirements.push(opReq);
+                        }
+                    } else {
+                        if (!acc[req.number]) acc[req.number] = [];
+                        if (acc[req.number].some(item => item.isUploaded)) return;
+
+                        const baseReq = {
+                            id: req.id,
+                            name: req.document,
+                            status: false,
+                            background: '',
+                            comment: null,
+                            isUploaded: false,
+                            procedureRequirementId: req.id,
+                            number: req.number
+                        };
+
+                        if (sub) {
+                            baseReq.status = true;
+                            baseReq.background = sub.is_uploaded ? 'bg-success-blue' : 'bg-success-green';
+                            baseReq.comment = sub.comment;
+                            baseReq.isUploaded = sub.is_uploaded;
+
+                            if (baseReq.isUploaded) {
+                                acc[req.number] = [baseReq];
+                                return;
+                            }
+                        }
+
+                        acc[req.number].push(baseReq);
+                    }
+                });
+
+                this.requirementList = acc;
             }
 
-            return r;
+            this.getAditionalRequirements();
         },
         getAditionalRequirements() {
             if (!this.modality) {

--- a/resources/views/eco_com/show.blade.php
+++ b/resources/views/eco_com/show.blade.php
@@ -171,7 +171,7 @@ El trámite es de tipo <strong>{{$economic_complement->eco_com_reception_type->n
                 </eco-com-legal-guardian>
             </div>
             <div id="tab-eco-com-summited-document" class="tab-pane">
-                <eco-com-step1-requirements-edit :affiliate="{{ $affiliate }}" :eco-com="{{ $economic_complement }}" :submitted="{{$submit_documents}}" :rol="{{Muserpol\Helpers\Util::getRol()->id}}">
+                <eco-com-step1-requirements-edit :affiliate="{{ $affiliate }}" :eco-com="{{ $economic_complement }}" :requirements='@json($requirements)' :submitted="{{$submit_documents}}" :rol="{{Muserpol\Helpers\Util::getRol()->id}}">
                 </eco-com-step1-requirements-edit>
             </div>
             <div id="tab-eco-com-qualification" class="tab-pane">

--- a/resources/views/quota_aid/show.blade.php
+++ b/resources/views/quota_aid/show.blade.php
@@ -313,7 +313,7 @@
                                     {{-- @can('view',new Muserpol\Models\RetirementFund\RetFunSubmittedDocument) --}}
                                         {{-- @include('ret_fun.legal_review', ['affiliate'=>$affiliate,'quota_aid'=>$quota_aid,'documents'=>$documents])                                 --}}
                                 <quota-aid-step1-requirements-edit 
-                                    :affiliate="{{ $affiliate }}" :quota_aid="{{ $quota_aid }}" :submitted="{{$submit_documents}}" :rol="{{Muserpol\Helpers\Util::getRol()->id}}"
+                                    :affiliate="{{ $affiliate }}" :quota_aid="{{ $quota_aid }}" :requirements='@json($requirements)'  :submitted="{{$submit_documents}}" :rol="{{Muserpol\Helpers\Util::getRol()->id}}"
                                 >
                                 </quota-aid-step1-requirements-edit>
                                     {{-- @endcan --}}


### PR DESCRIPTION
Se realizaron los siguientes cambios:

- (CE, CAM) Se cambio la lógica para mostrar la edición de documentos de un trámite ya creado, desacoplando la conexión con los microservicios, ahora se muestran los documentos de la tabla submit documents. Esto sirve para mostrar los requisitos del trámite en el mismo estado de cuando se creo.
- (FR, CE, CAM) Se elimino un input oculto que permitía desmarcar a los requisitos escaneados incluso si estos estaban bloqueados.
- (FR, CE, CAM)  Se añadió la opción de que en trámites antiguos se puedan visualizar los documentos eliminados a causa de la consolidación de requisitos.