### PR TITLE
fix: Alineación flujo complemento económico kiosco digital

### DIFF
--- a/app/Observers/EconomicComplementObserver.php
+++ b/app/Observers/EconomicComplementObserver.php
@@ -17,7 +17,7 @@ class EconomicComplementObserver
     public function created(EconomicComplement $eco_com)
     {
         $user = Auth::user();
-        $user_id = $user ? $user->id : 171;
+        $user_id = $user ? $user->id : ($eco_com->user_id ?? 171);
         $username = $user ? $user->username : 'system';
         // $rol = Util::getRol();
         // $wfStateId = null;
@@ -166,7 +166,7 @@ class EconomicComplementObserver
 
     public function deleted(EconomicComplement $eco_com) {
         $user = Auth::user();
-        $userId = $user ? $user->id : 171;
+        $userId = $user ? $user->id : ($eco_com->user_id ?? 171);
         $username = $user ? $user->username : 'system';
         $rol = Util::getRol();
         $wfStateId = null;


### PR DESCRIPTION
- Corregir showFormatedEcoCom: usar route param en vez de request field
- Agregar creación de procedure_records en createEcoCom para kiosco
- Fix replicateBeneficiary para aceptar cell_phone_number
- Fix addObservations: usar user_id 232 (kiosco) en vez de auth
- Observer: fallback user_id con ->user_id ?? 171
- Observer: null-safe access para origin_channel con optional()
- Observer: username fallback 'system' cuando no hay auth